### PR TITLE
fix:Sales Invoice Data sync avoid validation when status=Overdue

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -322,7 +322,7 @@ class SalesInvoice(SellingController):
 				frappe.throw(_("Total payments amount can't be greater than {}").format(-invoice_total))
 
 	def validate_pos_paid_amount(self):
-		if len(self.payments) == 0 and self.is_pos:
+		if len(self.payments) == 0 and self.is_pos and self.status != "Overdue":
 			frappe.throw(_("At least one mode of payment is required for POS invoice."))
 
 	def check_if_consolidated_invoice(self):


### PR DESCRIPTION
Sales Invoice Data sync avoids validation when status=Overdue
Validation message : "At least one mode of payment is required for POS invoice"